### PR TITLE
feat/5/entitiy

### DIFF
--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclub/entity/ReadingClub.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclub/entity/ReadingClub.java
@@ -1,0 +1,30 @@
+package com.ohgiraffers.secondbackend.readingclub.entity;
+
+import jakarta.persistence.*;
+import org.hibernate.annotations.CreationTimestamp;
+
+import java.time.LocalDateTime;
+
+@Entity
+@Table(name = "reading_club")
+public class ReadingClub {
+    @Id
+    @Column(name = "club_id")
+    @GeneratedValue(strategy = GenerationType.IDENTITY)
+    private int id;
+    @Column(name = "club_name", nullable = false)
+    private String name;
+    @Column(name = "club_description")
+    private String description;
+    @Enumerated(EnumType.STRING)
+    @Column(name = "club_status", nullable = false)
+    private ReadingClubStatus status;
+    @Column(name = "created_at", nullable = false)
+    @CreationTimestamp
+    private LocalDateTime createdAt;
+    @Column(name = "host_user_id", nullable = false)  // user 테이블 fk
+    private int userId;
+    @Column(name = "category", nullable = false)      // category 테이블 fk
+    private int categoryId;
+
+}

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclub/entity/ReadingClubStatus.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclub/entity/ReadingClubStatus.java
@@ -1,0 +1,7 @@
+package com.ohgiraffers.secondbackend.readingclub.entity;
+
+public enum ReadingClubStatus {
+    OPEN,           // 모집 중
+    CLOSED,         // 모집 마감
+    FINISHED        // 종료
+}


### PR DESCRIPTION
feature/5/readingclubentity create

## 📌 Related Issue
closed #5 

## 🚀 Description
독서모임 엔티티 생성했고 상태는 enum으로 관리
추후 가져올 유저 id랑 카테고리 id는 같은 db라 알고있음에도 서비스를 구분하기에 int값으로 관리
나중에 long으로 변경할수도있습니다 null 값이 허용될수 있게