### PR TITLE
feat/11/review-modify

### DIFF
--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/controller/ReadingClubReviewController.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/controller/ReadingClubReviewController.java
@@ -27,4 +27,16 @@ public class ReadingClubReviewController {
 
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
+
+    @PutMapping("/review-modify/{reviewId}")
+    public ResponseEntity<ReadingClubReviewResponseDTO> modifyReview(@PathVariable Long reviewId,
+                                                                     @RequestBody ReadingClubReviewRequestDTO request,
+                                                                     Authentication authentication){
+
+        String username = authentication.getName();
+
+        ReadingClubReviewResponseDTO response = reviewService.modifyReview(reviewId, request, username);
+
+        return ResponseEntity.ok(response);
+    }
 }

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/entity/ReadingClubReview.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/entity/ReadingClubReview.java
@@ -49,4 +49,9 @@ public class ReadingClubReview {
         this.reviewContent = reviewContent;
         this.likeTotal = 0L;
     }
+
+    public void update(String reviewTitle, String reviewContent) {
+        this.reviewTitle = reviewTitle;
+        this.reviewContent = reviewContent;
+    }
 }

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/repository/ReadingClubReviewRepository.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/repository/ReadingClubReviewRepository.java
@@ -4,8 +4,14 @@ import com.ohgiraffers.secondbackend.readingclubreview.entity.ReadingClubReview;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
+import java.util.Optional;
+
 @Repository
 public interface ReadingClubReviewRepository extends JpaRepository<ReadingClubReview, Long> {
 
     boolean existsByClubIdAndWriterId(long clubId, long writerId);
+
+    Optional<ReadingClubReview> findByReviewIdAndWriterId(Long reviewId, Long writerId);
+
+
 }

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/service/ReadingClubReviewService.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/service/ReadingClubReviewService.java
@@ -5,12 +5,14 @@ import com.ohgiraffers.secondbackend.readingclub.repository.ReadingClubRepositor
 import com.ohgiraffers.secondbackend.readingclubreview.dto.request.ReadingClubReviewRequestDTO;
 import com.ohgiraffers.secondbackend.readingclubreview.dto.response.ReadingClubReviewResponseDTO;
 import com.ohgiraffers.secondbackend.readingclubreview.entity.ReadingClubReview;
+import com.ohgiraffers.secondbackend.readingclubreview.exception.NotFoundException;
 import com.ohgiraffers.secondbackend.readingclubreview.repository.ReadingClubReviewRepository;
 import com.ohgiraffers.secondbackend.user.entity.User;
 import com.ohgiraffers.secondbackend.user.repository.UserRepository;
 import jakarta.transaction.Transactional;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.data.crossstore.ChangeSetPersister.*;
 import org.springframework.security.access.AccessDeniedException;
 import org.springframework.security.core.userdetails.UsernameNotFoundException;
 import org.springframework.stereotype.Service;
@@ -58,6 +60,29 @@ public class ReadingClubReviewService {
 
         ReadingClubReview saved = reviewRepository.save(review);
 
+        return ReadingClubReviewResponseDTO.from(saved);
+    }
+
+
+    public ReadingClubReviewResponseDTO modifyReview(Long reviewId, ReadingClubReviewRequestDTO request, String username) {
+
+        // 1. username으로 유저 조회
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 유저입니다."));
+
+
+        Long userId = user.getId();
+
+        // 2. 이 유저가 쓴 해당 리뷰 찾기
+        ReadingClubReview review = reviewRepository
+                .findByReviewIdAndWriterId(reviewId, userId)
+                .orElseThrow(() -> new AccessDeniedException("해당 리뷰를 수정할 수 있는 권한이 없습니다."));
+
+        // 3. 제목/내용 수정
+        review.update(request.getReviewTitle(), request.getReviewContent());
+
+        // 4. 저장 후 DTO로 변환
+        ReadingClubReview saved = reviewRepository.save(review);
         return ReadingClubReviewResponseDTO.from(saved);
     }
 }


### PR DESCRIPTION
## 📌 Related Issue
closed #11

## 🚀 Description
독서모임 후기 수정 기능 구현

1. 유저 조회 
   - `userRepository`를 사용해 유저 존재 여부를 검증했습니다.
2. 이 유저가 쓴 리뷰 찾기
   - `ReadingClubReviewRepository`의 `findByReviewIdAndWriterId()` 메서드를 사용하여 
     요청한 사용자가 작성한 리뷰가 맞는지 검증했습니다.

로그인 후 수정하고자 하는 리뷰 아이디를 검색해 수정합니다.

---

### 🧪 POSTMAN 테스트 방법
1. 로그인 후 발급된 accessToken을 복사합니다 (`"` 제외).
2. 아래 API로 PUT 요청을 보냅니다:
PUT http://localhost:8080/reading-club-review//review-modify/{reviewId}
3. **Headers**
| Key | Value |
| Authorization | Bearer accessToken |
| Content-Type | application/json |

4. **Body (raw / JSON)**
```json
{
  "reviewTitle": "수정할 제목",
  "reviewContent": "수정할 내용"
}
