### PR TITLE
feat/12/review-delete

### DIFF
--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/controller/ReadingClubReviewController.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/controller/ReadingClubReviewController.java
@@ -1,8 +1,10 @@
 package com.ohgiraffers.secondbackend.readingclubreview.controller;
 
+import com.ohgiraffers.secondbackend.readingclub.entity.ReadingClub;
 import com.ohgiraffers.secondbackend.readingclubreview.dto.request.ReadingClubReviewRequestDTO;
 import com.ohgiraffers.secondbackend.readingclubreview.dto.response.ReadingClubReviewResponseDTO;
 import com.ohgiraffers.secondbackend.readingclubreview.service.ReadingClubReviewService;
+import com.oracle.svm.core.annotate.Delete;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -39,4 +41,17 @@ public class ReadingClubReviewController {
 
         return ResponseEntity.ok(response);
     }
+
+    @DeleteMapping("/review-delete/{reviewId}")
+    public ResponseEntity<Void> deleteReview(@PathVariable Long reviewId,
+                                             Authentication authentication)
+    {
+        String username = authentication.getName();
+
+        reviewService.deleteReview(reviewId, username);
+
+        return ResponseEntity.noContent().build();
+
+    }
+
 }

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/exception/NotFoundException.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/exception/NotFoundException.java
@@ -1,0 +1,12 @@
+package com.ohgiraffers.secondbackend.readingclubreview.exception;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.NOT_FOUND)
+public class NotFoundException extends RuntimeException {
+
+    public NotFoundException(String message) {
+        super(message);
+    }
+}

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/repository/ReviewCommentRepository.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/repository/ReviewCommentRepository.java
@@ -1,0 +1,11 @@
+package com.ohgiraffers.secondbackend.readingclubreview.repository;
+
+import com.ohgiraffers.secondbackend.readingclubreview.entity.ReviewComment;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewCommentRepository extends JpaRepository<ReviewComment, Long> {
+
+    void deleteByClubReviewId(Long clubReviewId);
+}

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/repository/ReviewLikeRepository.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/repository/ReviewLikeRepository.java
@@ -1,0 +1,11 @@
+package com.ohgiraffers.secondbackend.readingclubreview.repository;
+
+import com.ohgiraffers.secondbackend.readingclubreview.entity.ReviewLike;
+import org.springframework.data.jpa.repository.JpaRepository;
+import org.springframework.stereotype.Repository;
+
+@Repository
+public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
+
+    void deleteByClubReviewId(Long clubReviewId);
+}


### PR DESCRIPTION
## 📌 Related Issue
closed #12 
## 🚀 Description
독서모임후기삭제

자신이 작성한 후기인지 검증 후 삭제합니다.
댓글과 좋아요는 Repository의 메소드를 통해 함께 삭제되도록 작성해두었으나 추후 cascade 처리로 수정될 수 있습니다.

### POSTMAN 테스트 방법
1. 로그인 후 발급된 accessToken을 복사합니다 (`"` 제외).
2. 아래 API로 DELETE 요청을 보냅니다:
DELETE http://localhost:8080/reading-club-review/review-delete/{reviewId}
3. **Headers**
| Key | Value |
| Authorization | Bearer accessToken |
<img width="711" height="556" alt="스크린샷 2025-12-07 오후 5 59 34" src="https://github.com/user-attachments/assets/0082b9d3-545d-45bd-96f8-3bcbeea56013" />
