### PR TITLE
Feat/14/reviewcomment create

### DIFF
--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/controller/ReadingClubReviewController.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/controller/ReadingClubReviewController.java
@@ -12,13 +12,13 @@ import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
 
 @RestController
-@RequestMapping("/reading-club-review")
+@RequestMapping("/review")
 @RequiredArgsConstructor
 public class ReadingClubReviewController {
 
     private final ReadingClubReviewService reviewService;
 
-    @PostMapping("/{clubId}/review-create")
+    @PostMapping("/clubId/{clubId}")
     public ResponseEntity<ReadingClubReviewResponseDTO> createReview(@PathVariable long clubId, @RequestBody ReadingClubReviewRequestDTO request,
                                                                      Authentication authentication){
 
@@ -30,7 +30,7 @@ public class ReadingClubReviewController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PutMapping("/review-modify/{reviewId}")
+    @PutMapping("/reviewId/{reviewId}")
     public ResponseEntity<ReadingClubReviewResponseDTO> modifyReview(@PathVariable Long reviewId,
                                                                      @RequestBody ReadingClubReviewRequestDTO request,
                                                                      Authentication authentication){
@@ -42,7 +42,7 @@ public class ReadingClubReviewController {
         return ResponseEntity.ok(response);
     }
 
-    @DeleteMapping("/review-delete/{reviewId}")
+    @DeleteMapping("/reviewId/{reviewId}")
     public ResponseEntity<Void> deleteReview(@PathVariable Long reviewId,
                                              Authentication authentication)
     {

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/controller/ReadingClubReviewController.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/controller/ReadingClubReviewController.java
@@ -1,10 +1,8 @@
 package com.ohgiraffers.secondbackend.readingclubreview.controller;
 
-import com.ohgiraffers.secondbackend.readingclub.entity.ReadingClub;
 import com.ohgiraffers.secondbackend.readingclubreview.dto.request.ReadingClubReviewRequestDTO;
 import com.ohgiraffers.secondbackend.readingclubreview.dto.response.ReadingClubReviewResponseDTO;
 import com.ohgiraffers.secondbackend.readingclubreview.service.ReadingClubReviewService;
-import com.oracle.svm.core.annotate.Delete;
 import lombok.RequiredArgsConstructor;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -19,7 +17,7 @@ public class ReadingClubReviewController {
     private final ReadingClubReviewService reviewService;
 
     @PostMapping("/clubId/{clubId}")
-    public ResponseEntity<ReadingClubReviewResponseDTO> createReview(@PathVariable long clubId, @RequestBody ReadingClubReviewRequestDTO request,
+    public ResponseEntity<ReadingClubReviewResponseDTO> createReview(@PathVariable Long clubId, @RequestBody ReadingClubReviewRequestDTO request,
                                                                      Authentication authentication){
 
         // 로그인한 사용자의 username 가져오기

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/dto/response/ReadingClubReviewResponseDTO.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/dto/response/ReadingClubReviewResponseDTO.java
@@ -21,8 +21,8 @@ public class ReadingClubReviewResponseDTO {
     public static ReadingClubReviewResponseDTO from(ReadingClubReview review) {
         return ReadingClubReviewResponseDTO.builder()
                 .reviewId(review.getReviewId())
-                .clubId(review.getClubId())
-                .writerId(review.getWriterId())
+                .clubId(review.getClubId().getId())
+                .writerId(review.getWriterId().getId())
                 .reviewTitle(review.getReviewTitle())
                 .reviewContent(review.getReviewContent())
                 .likeTotal(review.getLikeTotal())

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/entity/ReadingClubReview.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/entity/ReadingClubReview.java
@@ -1,5 +1,7 @@
 package com.ohgiraffers.secondbackend.readingclubreview.entity;
 
+import com.ohgiraffers.secondbackend.readingclub.entity.ReadingClub;
+import com.ohgiraffers.secondbackend.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -17,13 +19,17 @@ public class ReadingClubReview {
     @Id
     @Column(name = "club_review_id")
     @GeneratedValue(strategy = GenerationType.IDENTITY)
-    private long reviewId;
+    private Long reviewId;
 
-    @Column(name = "club_id", nullable = false) // reading_club 테이블 fk
-    private long clubId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_id", nullable = false)  // FK 컬럼 이름 그대로 사용
+    private ReadingClub clubId;
 
-    @Column(name = "writer_id", nullable = false) // user 테이블 fk
-    private long writerId;
+
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "writer_id", nullable = false)  // FK 컬럼 이름 그대로
+    private User writerId;
+
 
     @Column(name = "review_title", nullable = false)
     private String reviewTitle;
@@ -39,8 +45,8 @@ public class ReadingClubReview {
     private LocalDateTime createdAt;
 
     @Builder
-    public ReadingClubReview(long clubId,
-                             long writerId,
+    public ReadingClubReview(ReadingClub clubId,
+                             User writerId,
                              String reviewTitle,
                              String reviewContent) {
         this.clubId = clubId;

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/entity/ReviewComment.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/entity/ReviewComment.java
@@ -1,5 +1,6 @@
 package com.ohgiraffers.secondbackend.readingclubreview.entity;
 
+import com.ohgiraffers.secondbackend.user.entity.User;
 import jakarta.persistence.*;
 import lombok.Builder;
 import lombok.Getter;
@@ -19,14 +20,17 @@ public class ReviewComment {
     @Column(name = "review_comment_id")
     private Long reviewCommentId;
 
-    @Column(name = "club_review_id", nullable = false)  // review 테이블 FK
-    private Long clubReviewId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "club_review_id", nullable = false)
+    private ReadingClubReview review;    // ✔ 어떤 리뷰에 달린 댓글인지
 
-    @Column(name = "user_id", nullable = false)         // user 테이블 FK
-    private Long userId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "user_id", nullable = false)
+    private User user;                  // ✔ 누가 썼는지
 
-    @Column(name = "parent_comment_id")                 // 부모 댓글 (대댓글용), 루트 댓글이면 null
-    private Long parentCommentId;
+    @ManyToOne(fetch = FetchType.LAZY)
+    @JoinColumn(name = "parent_comment_id")
+    private ReviewComment parent;       // ✔ 부모 댓글, 없으면 null
 
     @Column(name = "comment_detail", nullable = false)
     private String commentDetail;
@@ -38,18 +42,15 @@ public class ReviewComment {
     @Column(name = "delete_comment", nullable = false)
     private boolean deleteComment = false;
 
-
     @Builder
-    public ReviewComment(Long clubReviewId,
-                         Long userId,
-                         Long parentCommentId,
+    public ReviewComment(ReadingClubReview review,
+                         User user,
+                         ReviewComment parent,
                          String commentDetail) {
-        this.clubReviewId = clubReviewId;
-        this.userId = userId;
-        this.parentCommentId = parentCommentId; // null이면 루트 댓글
+        this.review = review;
+        this.user = user;
+        this.parent = parent;
         this.commentDetail = commentDetail;
         this.deleteComment = false;
     }
-
-
 }

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/repository/ReadingClubReviewRepository.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/repository/ReadingClubReviewRepository.java
@@ -1,6 +1,8 @@
 package com.ohgiraffers.secondbackend.readingclubreview.repository;
 
+import com.ohgiraffers.secondbackend.readingclub.entity.ReadingClub;
 import com.ohgiraffers.secondbackend.readingclubreview.entity.ReadingClubReview;
+import com.ohgiraffers.secondbackend.user.entity.User;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
 
@@ -9,9 +11,9 @@ import java.util.Optional;
 @Repository
 public interface ReadingClubReviewRepository extends JpaRepository<ReadingClubReview, Long> {
 
-    boolean existsByClubIdAndWriterId(long clubId, long writerId);
+    boolean existsByClubIdAndWriterId(ReadingClub clubId, User writerId);
 
-    Optional<ReadingClubReview> findByReviewIdAndWriterId(Long reviewId, Long writerId);
+    Optional<ReadingClubReview> findByReviewIdAndWriterId(Long reviewId, User writerId);
 
 
 }

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/repository/ReviewCommentRepository.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/repository/ReviewCommentRepository.java
@@ -1,5 +1,6 @@
 package com.ohgiraffers.secondbackend.readingclubreview.repository;
 
+import com.ohgiraffers.secondbackend.readingclubreview.entity.ReadingClubReview;
 import com.ohgiraffers.secondbackend.readingclubreview.entity.ReviewComment;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -7,5 +8,4 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReviewCommentRepository extends JpaRepository<ReviewComment, Long> {
 
-    void deleteByClubReviewId(Long clubReviewId);
 }

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/repository/ReviewLikeRepository.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/repository/ReviewLikeRepository.java
@@ -1,5 +1,6 @@
 package com.ohgiraffers.secondbackend.readingclubreview.repository;
 
+import com.ohgiraffers.secondbackend.readingclubreview.entity.ReadingClubReview;
 import com.ohgiraffers.secondbackend.readingclubreview.entity.ReviewLike;
 import org.springframework.data.jpa.repository.JpaRepository;
 import org.springframework.stereotype.Repository;
@@ -7,5 +8,4 @@ import org.springframework.stereotype.Repository;
 @Repository
 public interface ReviewLikeRepository extends JpaRepository<ReviewLike, Long> {
 
-    void deleteByClubReviewId(Long clubReviewId);
 }


### PR DESCRIPTION
## 📌 Related Issue
closed #14 
## 🚀 Description
독서모임후기글 댓글 생성

해당 review에 대한 댓글이 아닌 경우, 대댓글에 대한 대댓글인 경우 댓글 생성이 되지 않도록 했습니다.
parentCommentId가 null인 경우 댓글, null이 아닌 경우 대댓글입니다.

추가로 엔티티에 fk 연관관계 추가했으며 url 수정했습니다.

독서모임후기글 작성
POST/review/clubId/{clubId}      - 후기글 생성
PUT/review/reviewId/{reviewId} - 후기글 수정
DELETE/review/reviewId/{reviewId} - 후기글 삭제

###  POSTMAN 테스트 방법
1. 로그인 후 발급된 accessToken을 복사합니다 (`"` 제외).
2. 아래 API로 POST 요청을 보냅니다:
POST http://localhost:8080/review/comment/reviewId/{reviewId}
3. **Headers**
| Key | Value |
| Authorization | Bearer accessToken |
| Content-Type | application/json |

4. **Body (raw / JSON)**
댓글
```json
{
  "commentDetail": "댓글 내용"
}
```

대댓글
```json
{
  "commentDetail": "댓글 내용",
  "parentCommentId" : id
}
```
