### PR TITLE
feat/100/comment-delete

### DIFF
--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/controller/ReviewCommentController.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/controller/ReviewCommentController.java
@@ -28,7 +28,7 @@ public class ReviewCommentController {
         return ResponseEntity.status(HttpStatus.CREATED).body(response);
     }
 
-    @PatchMapping("/reviewId/{commentId}")
+    @PatchMapping("/commentId/{commentId}")
     public ResponseEntity<ReviewCommentResponseDTO> modifyComments(@PathVariable("commentId") Long commentId,
                                                                    @RequestBody ReviewCommentRequestDTO request,
                                                                    Authentication  authentication) {
@@ -37,5 +37,15 @@ public class ReviewCommentController {
         ReviewCommentResponseDTO response = reviewCommentService.modifyComment(commentId, request, username);
 
         return ResponseEntity.ok(response);
+    }
+
+    @DeleteMapping("/commentId/{commentId}")
+    public ResponseEntity<Void> deleteComment(@PathVariable("commentId") Long commentId,
+                                              Authentication authentication) {
+        String username = authentication.getName();
+
+        reviewCommentService.deleteComment(commentId, username);
+
+        return ResponseEntity.noContent().build();
     }
 }

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/service/ReadingClubReviewService.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/service/ReadingClubReviewService.java
@@ -98,7 +98,6 @@ public class ReadingClubReviewService {
         User user = userRepository.findByUsername(username)
                 .orElseThrow(() -> new UsernameNotFoundException("존재하지 않는 유저입니다."));
 
-        Long userId = user.getId();
 
         // 2. 이 유저가 쓴 해당 리뷰 찾기
         ReadingClubReview review = reviewRepository

--- a/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/service/ReviewCommentService.java
+++ b/2nd-backend/src/main/java/com/ohgiraffers/secondbackend/readingclubreview/service/ReviewCommentService.java
@@ -78,7 +78,7 @@ public class ReviewCommentService {
         // 2. 이 유저가 작성한 해당 댓글 찾기 (아니면 권한 없음)
         ReviewComment comment = commentRepository
                 .findByReviewCommentIdAndUser(commentId, user)
-                .orElseThrow(() -> new AccessDeniedException("자신이 작성한 댓글이 아니므로 수정할 수 없습니다."));
+                .orElseThrow(() -> new AccessDeniedException("해당 댓글을 수정할 수 있는 권한이 없습니다."));
 
         // 내용 수정
         comment.updateContent(request.getCommentDetail());
@@ -86,5 +86,19 @@ public class ReviewCommentService {
         ReviewComment saved = commentRepository.save(comment);
         return ReviewCommentResponseDTO.from(saved);
 
+    }
+
+    public void deleteComment(Long commentId, String username) {
+
+        // 유저 조회
+        User user = userRepository.findByUsername(username)
+                .orElseThrow(() -> new UsernameNotFoundException(username));
+
+        // 이 유저가 쓴 해당 댓글 찾기
+        ReviewComment comment = commentRepository
+                .findByReviewCommentIdAndUser(commentId, user)
+                .orElseThrow(() -> new AccessDeniedException("해당 댓글을 삭제할 수 있는 권한이 없습니다."));
+
+        commentRepository.delete(comment);
     }
 }


### PR DESCRIPTION
## 📌 Related Issue
closed #100 
## 🚀 Description
독서모임후기글 댓글 삭제

자신이 작성한 댓글만 삭제할 수 있습니다.
추가로 댓글 수정 url 수정했습니다.
PATCH/review/comment/commentId/{commentId}

### 🧪 POSTMAN 테스트 방법
1. 로그인 후 발급된 accessToken을 복사합니다 (`"` 제외).
2. 아래 API로 DELETE 요청을 보냅니다:
DELETE http://localhost:8080/review/comment/commentId/{commentId}
3. **Headers**
| Key | Value |
| Authorization | Bearer accessToken |
